### PR TITLE
api: show Notes for 7.1 and commonize with 7.0

### DIFF
--- a/_data/table/api.yml
+++ b/_data/table/api.yml
@@ -1,6 +1,7 @@
 - name: '7.1'
+  url: '/Notes-for-Android-7.x'
 - name: '7.0'
-  url: '/Notes-for-Android-7.0'
+  url: '/Notes-for-Android-7.x'
 - name: '6.0'
   url: '/Notes-for-Android-6.0'
   checked: true


### PR DESCRIPTION
This requires us to rename the wiki page
to "Notes-for-Android-7.x"

Signed-off-by: Alex Naidis <alex.naidis@linux.com>