### PR TITLE
Delete link to Google Play

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -62,8 +62,6 @@ title: "Open GApps App"
         {% if site.betaapp %}<br/>
         <a class="mdl-button mdl-button--accent mdl-js-button mdl-js-ripple-effect" href="/app/opengapps-app-v{{site.betaapp.versioncode}}.apk">Download Beta</a>{% endif %}
         <br/>
-        <a class="mdl-button mdl-button--accent mdl-js-button mdl-js-ripple-effect" href="https://play.google.com/store/apps/details?id={{site.app.packagename}}&hl=en&referrer=utm_source%3Dopengapps%26utm_medium%3Dapplink">Visit Play Store</a>
-        <br/>
         <a id="show-dialog" class="mdl-button mdl-button--accent mdl-js-button mdl-js-ripple-effect">Verification Details</a>
       </div>
     </div>


### PR DESCRIPTION
Appears that the app has vanished from there, so no use linking to it.