### PR TITLE
Remove deprecated Google+ links

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -40,11 +40,6 @@ footerlinks:
     link: https://facebook.com/opengapps
     customicon: '<svg style="width:24px;height:24px" viewBox="0 0 24 24"><path fill="currentColor" d="M17,2V2H17V6H15C14.31,6 14,6.81 14,7.5V10H14L17,10V14H14V22H10V14H7V10H10V6A4,4 0 0,1 14,2H17Z" /></svg>'
     color: "#3b5998"
-  - name: Google+
-    id: googlepluslink
-    link: https://plus.google.com/+OpengappsOrg
-    customicon: '<svg style="width:24px;height:24px" viewBox="0 0 24 24"><path fill="currentColor" d="M23,11H21V9H19V11H17V13H19V15H21V13H23M8,11V13.4H12C11.8,14.4 10.8,16.4 8,16.4C5.6,16.4 3.7,14.4 3.7,12C3.7,9.6 5.6,7.6 8,7.6C9.4,7.6 10.3,8.2 10.8,8.7L12.7,6.9C11.5,5.7 9.9,5 8,5C4.1,5 1,8.1 1,12C1,15.9 4.1,19 8,19C12,19 14.7,16.2 14.7,12.2C14.7,11.7 14.7,11.4 14.6,11H8Z" /></svg>'
-    color: "#d34836"
   - name: Twitter
     id: twitterlink
     link: https://twitter.com/opengapps

--- a/_data/tooltips.yml
+++ b/_data/tooltips.yml
@@ -17,8 +17,6 @@ common:
     info: Open GApps Blog
   - tag: facebooklink
     info: Open GApps on Facebook
-  - tag: googlepluslink
-    info: Open GApps on Google+
   - tag: twitterlink
     info: Open GApps on Twitter
   - tag: youtubelink

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,7 +32,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="keywords" content="{{site.keywords}}">
 <meta name="description" content="{{site.description}}">
-<link rel="publisher" href="https://plus.google.com/+OpengappsOrg">
 <html itemscope itemtype="http://schema.org/Organization">
 <meta itemprop="name" content="{{site.org}}">
 <meta itemprop="description" content="{{site.description}}">


### PR DESCRIPTION
As Google+ is now deprecated since April 2019 it is perhaps time to remove these links...