### PR TITLE
Add support for Android 11.0 for Genymotion PaaS

### DIFF
--- a/api/v1/genymotion-cloud-paas.json
+++ b/api/v1/genymotion-cloud-paas.json
@@ -84,6 +84,10 @@
     "10.0": {
       "md5sum": "086dc823580d111b39c56446f6e70f4c",
       "url": "https://master.dl.sourceforge.net/project/opengapps/x86_64/20210325/open_gapps-x86_64-10.0-pico-20210325.zip"
+    },
+    "11.0": {
+      "md5sum": "0cea073b7e05e08e17d7337a67fcc02c",
+      "url": "https://master.dl.sourceforge.net/project/opengapps/x86_64/20210812/open_gapps-x86_64-11.0-pico-20210812.zip"
     }
   }
 }


### PR DESCRIPTION
Hi @mfonville

I hope you're well.
New version supported now. Thanks for adding Android 11.0 to the list of Opengapps packages.

Thanks,
Julien